### PR TITLE
Implement module blacklist feature

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
@@ -167,7 +167,8 @@ public class ModulesScreen extends TabScreen {
         List<Module> modules = new ArrayList<>();
 
         for (Module module : Modules.get().getAll()) {
-            if (module.favorite) {
+            if (module.favorite
+                && !Config.get().blacklistedModules.get().contains(module)) {
                 modules.add(module);
             }
         }
@@ -205,7 +206,8 @@ public class ModulesScreen extends TabScreen {
             List<Module> moduleList = new ArrayList<>();
             for (Category category : Modules.loopCategories()) {
                 for (Module module : Modules.get().getGroup(category)) {
-                    if (!Config.get().hiddenModules.get().contains(module)) {
+                    if (!Config.get().hiddenModules.get().contains(module)
+                        && !Config.get().blacklistedModules.get().contains(module)) {
                         moduleList.add(module);
                     }
                 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -12,6 +12,15 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.System;
 import meteordevelopment.meteorclient.systems.Systems;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.systems.modules.combat.*;
+import meteordevelopment.meteorclient.systems.modules.player.*;
+import meteordevelopment.meteorclient.systems.modules.movement.*;
+import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
+import meteordevelopment.meteorclient.systems.modules.movement.speed.Speed;
+import meteordevelopment.meteorclient.systems.modules.render.*;
+import meteordevelopment.meteorclient.systems.modules.world.*;
+import meteordevelopment.meteorclient.systems.modules.misc.*;
+import meteordevelopment.meteorclient.systems.modules.misc.swarm.Swarm;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
@@ -101,6 +110,47 @@ public class Config extends System<Config> {
     public final Setting<List<Module>> hiddenModules = sgModules.add(new ModuleListSetting.Builder()
         .name("hidden-modules")
         .description("Prevent these modules from being rendered as options in the clickgui.")
+        .build()
+    );
+
+    public final Setting<List<Module>> blacklistedModules = sgModules.add(new ModuleListSetting.Builder()
+        .name("blacklisted-modules")
+        .description("Modules that will not be shown in the clickgui or HUD.")
+        .defaultValue(
+            AnchorAura.class, AntiAnvil.class, AntiBed.class, AutoAnvil.class,
+            AutoArmor.class, AutoCity.class, AutoEXP.class, AutoTrap.class,
+            AutoWeb.class, BedAura.class, BowAimbot.class, BowSpam.class,
+            Burrow.class, CrystalAura.class, Hitboxes.class, HoleFiller.class,
+            Quiver.class, SelfAnvil.class, SelfTrap.class, SelfWeb.class,
+            Surround.class,
+
+            AntiHunger.class, AutoEat.class, AutoClicker.class, AutoFish.class,
+            AutoGap.class, AutoMend.class, AutoReplenish.class, BreakDelay.class,
+            ChestSwap.class, EXPThrower.class, FakePlayer.class, FastUse.class,
+            GhostHand.class, InstantRebreak.class, LiquidInteract.class,
+            MiddleClickExtra.class, NoInteract.class, Portals.class,
+            PotionSaver.class, Reach.class, Rotation.class, SpeedMine.class,
+
+            AirJump.class, Anchor.class, AntiAFK.class, AntiVoid.class,
+            AutoJump.class, AutoWalk.class, AutoWasp.class, Blink.class,
+            BoatFly.class, ClickTP.class, ElytraBoost.class, ElytraFly.class,
+            EntityControl.class, EntitySpeed.class, FastClimb.class, Flight.class,
+            GUIMove.class, HighJump.class, Jesus.class, LongJump.class,
+            NoFall.class, NoSlow.class, Parkour.class, ReverseStep.class,
+            Slippy.class, Speed.class, Spider.class, Step.class,
+            TridentBoost.class, Velocity.class,
+
+            Tracers.class,
+
+            AutoBreed.class, AutoBrewer.class, AutoMount.class, AutoNametag.class,
+            AutoShearer.class, AutoSign.class, AutoSmelter.class, BuildHeight.class,
+            Collisions.class, EChestFarmer.class, HighwayBuilder.class,
+            LiquidFiller.class, MountBypass.class, NoGhostBlocks.class,
+            PacketMine.class, SpawnProofer.class, VeinMiner.class,
+
+            BetterBeacons.class, BetterChat.class, DiscordPresence.class,
+            MessageAura.class, NameProtect.class, Notebot.class, Swarm.class
+        )
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
@@ -9,6 +9,7 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.hud.*;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 
@@ -202,7 +203,8 @@ public class ActiveModulesHud extends HudElement {
         modules.clear();
 
         for (Module module : Modules.get().getActive()) {
-            if (!hiddenModules.get().contains(module)) modules.add(module);
+            if (!hiddenModules.get().contains(module)
+                && !Config.get().blacklistedModules.get().contains(module)) modules.add(module);
         }
 
         if (modules.isEmpty()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -155,6 +155,7 @@ public class Modules extends System<Modules> {
         Map<Module, Integer> modules = new ValueComparableMap<>(Comparator.naturalOrder());
 
         for (Module module : this.moduleInstances.values()) {
+            if (Config.get().blacklistedModules.get().contains(module)) continue;
             int score = Utils.searchLevenshteinDefault(module.title, text, false);
             if (Config.get().moduleAliases.get()) {
                 for (String alias : module.aliases) {
@@ -172,6 +173,7 @@ public class Modules extends System<Modules> {
         Map<Module, Integer> modules = new ValueComparableMap<>(Comparator.naturalOrder());
 
         for (Module module : this.moduleInstances.values()) {
+            if (Config.get().blacklistedModules.get().contains(module)) continue;
             int lowest = Integer.MAX_VALUE;
             for (SettingGroup sg : module.settings) {
                 for (Setting<?> setting : sg) {


### PR DESCRIPTION
## Summary
- add a `blacklisted-modules` setting in config with defaults
- hide blacklisted modules from the GUI favorites list and categories
- filter blacklisted modules from HUD active list
- exclude blacklisted modules from search results

## Testing
- `./gradlew build`